### PR TITLE
fix(nginx): fix url matching

### DIFF
--- a/puppet/modules/sw360/templates/nginx_liferay.conf.erb
+++ b/puppet/modules/sw360/templates/nginx_liferay.conf.erb
@@ -40,7 +40,7 @@ server {
 
     server_name liferay.localdomain;
 
-    location ~* /(manager|attachments|bdpimport|components|cvesearch|fossology|layouttpl|licenseinfo|licenses|moderation|projects|schedule|search|users|vendors|vulnerabilities)/ {
+    location ~* ^/(manager|attachments|bdpimport|components|cvesearch|fossology|layouttpl|licenseinfo|licenses|moderation|projects|schedule|search|users|vendors|vulnerabilities)/ {
         deny all;
     }
 


### PR DESCRIPTION
The old pattern prevents url keywords like 'components' even
if the url did not start with this name.

This prevents folders like 'components' even in the 'js' subdirectory.
This fix only prevents urls that starts with one of the keywords.