### PR TITLE
feat(setup): add vagrant aws provider

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,6 +34,10 @@ $ env | grep proxy
 ```
 $ vagrant plugin install vagrant-proxyconf
 ```
+* install the AWS plugin for vagrant if you setup AWS as provider
+```
+$ vagrant plugin install vagrant-aws
+```
 * adapt the Vagrantfile in the generate-box folder to set the proxy information
 ```
 $ vi shared/configuration.rb
@@ -67,6 +71,7 @@ The packages that are downloaded to `./shared/packages` are:
 * Apache Tomcat 7.0.67
 * Liferay 6.2.3-GA5
 * Couchdb-lucene 4.2.10
+* Postgresql-42.2.1
 
 ### 3. Generate base box
 
@@ -81,7 +86,7 @@ $ ./generate_box.sh
 This can take a while, but the the sw360-base box will be created, installed and ready
 to use.
 
-In a bit longer, the `generate_box.sh` script creates a new box based on a standard Ubuntu 14.04 box. Puppet then installs the required aptitude packages (openjdk-8-jdk, curl, unzip, couchdb, maven, gitcore, postgresql, nginx), generates the couchdblucene.war, unpacks tomcat and liferay, creates a new user "siemagrant" and adds a ssh key to it, so that the box can be accessed by ssh logging without password.
+In a bit longer, the `generate_box.sh` script creates a new box based on a standard Ubuntu 16.04 box. Puppet then installs the required aptitude packages (openjdk-8-jdk, curl, unzip, couchdb, maven, gitcore, postgresql, apache), generates the couchdblucene.war, unpacks tomcat and liferay, creates a new user "siemagrant" and adds a ssh key to it, so that the box can be accessed by ssh logging without password.
 
 ### 4. Provision a new box
 
@@ -116,7 +121,7 @@ $ cd sw360-single
 $ vagrant up
 ```
 The provisioning of the box (via puppet) configures liferay, tomcat8, and couchdb for the purpose of SW360 (port, paths, admin passwords, ...). 
-Additionally, nginx is configured to terminate TLS on port 8443 with a newly created self signed certificate.
+Additionally, apache is configured to terminate TLS on port 8443 with a newly created self signed certificate.
 If the option `sw360_install=true (default)` is used in the Vagrantfile, then also the code is fetched from Github, compiled with maven and deployed using tomcat:deploy (backend) and mvn install -Pdeploy (frontend) respectively. The fossology keys are copied to the appropriate directories. The tomcat instance for the backend
 and the liferay instance for the frontend start.
 
@@ -173,7 +178,12 @@ If you want to change the port on which sw360 is accessible from its default 844
   * obviously the Vagrant file: `config.vm.network "forwarded_port", guest: 8443, host: <your_port_here>`
   * and the liferay configuration in `puppet/modules/sw360/templates` since it generates absolute links: `web.server.https.port=<your_port_here>`
 
-### 9. License
+### 9. Problems
+
+Note: no proxy support for vagrant provider AWS.
+Please run the setup in a non proxy environment.
+
+### 10. License
 
 Copyright Siemens AG, 2013-2016. Part of the SW360 Portal Project.
 

--- a/download-packages.sh
+++ b/download-packages.sh
@@ -32,6 +32,7 @@ http://downloads.sourceforge.net/project/lportal/Liferay%20Portal/6.2.4%20GA5/li
 http://downloads.sourceforge.net/project/lportal/Liferay%20Portal/6.2.4%20GA5/liferay-portal-dependencies-6.2-ce-ga5-20151118111117117.zip liferay-dependencies.zip
 http://downloads.sourceforge.net/project/lportal/Liferay%20Portal/6.2.4%20GA5/liferay-portal-src-6.2-ce-ga5-20151118111117117.zip liferay-portal-src.zip
 https://github.com/rnewson/couchdb-lucene/archive/v1.0.2.tar.gz ./couchdb-lucene.tar.gz
+https://github.com/mitchellh/vagrant-aws/raw/master/dummy.box
 https://jdbc.postgresql.org/download/postgresql-42.2.1.jar postgresql.jar
 https://dist.apache.org/repos/dist/release/thrift/0.11.0/thrift-0.11.0.tar.gz'
 
@@ -102,6 +103,7 @@ setPermissions(){
 }
 addBoxToVagrant(){
         vagrant box add --force xenial-server-cloudimg-amd64-vagrant "xenial-server-cloudimg-amd64-vagrant.box"
+        vagrant box add --force aws-dummy "dummy.box"
 }
 
 # -----------------------------------------------------------------------------

--- a/generate-box/Vagrantfile
+++ b/generate-box/Vagrantfile
@@ -1,4 +1,4 @@
-# Copyright Siemens AG, 2013-2015. Part of the SW360 Portal Project.
+# Copyright Siemens AG, 2013-2018. Part of the SW360 Portal Project.
 #
 # Copying and distribution of this file, with or without modification,
 # are permitted in any medium without royalty provided the copyright
@@ -8,22 +8,73 @@
 # -*- mode: ruby -*-
 # vi: set ft=ruby :
 
-require_relative "../shared/configuration.rb"
+# Require configuration settings
+require_relative '../shared/configuration.rb'
+
+# Require the AWS provider plugin
+require 'vagrant-aws'
 
 VAGRANTFILE_API_VERSION = "2"
 
-# Default values for the sw360 configuration. Those values can be overridden by environment variables:
-
 Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
 
-  config.vm.provider "virtualbox" do |v|
-    v.name = SW360_basebox_name
-    v.customize ["modifyvm", :id, "--cpus", SW360_CPUs, "--memory", SW360_RAM]
-  end
-
-  # Every Vagrant virtual environment requires a box to build off of.
-  config.vm.box = 'xenial-server-cloudimg-amd64-vagrant'
   config.vm.define SW360_basebox_name
+
+  if SW360_provider == "virtualbox"
+
+    # Every Vagrant virtual environment requires a box to build off of.
+    config.vm.box = 'xenial-server-cloudimg-amd64-vagrant'
+
+    # Virtualbox provider
+    config.vm.provider "virtualbox" do |v|
+      v.name = SW360_basebox_name
+      v.customize ["modifyvm", :id, "--cpus", SW360_VB_CPUs, "--memory", SW360_VB_RAM]
+    end
+
+  else
+
+    # AWS can use a dummy box because its using a AMI anyway.
+    config.vm.box = 'aws-dummy'
+
+    # AWS provider
+    config.vm.provider :aws do |aws, override|
+
+      # Read AWS authentication information from environment variables
+      aws.access_key_id = ENV['AWS_ACCESS_KEY_ID']
+      aws.secret_access_key = ENV['AWS_SECRET_ACCESS_KEY']
+
+      # Specify SSH keypair to use for the EC2 instance
+      aws.keypair_name = SW360_AWS_keypair_name
+
+      # Specify region, AMI ID, and security group(s)
+      aws.region = SW360_AWS_region
+      aws.availability_zone = SW360_AWS_availability_zone
+      aws.ami = SW360_AWS_ami_base
+      aws.instance_type = SW360_AWS_instance_type
+      aws.subnet_id = SW360_AWS_subnet_id
+      aws.security_groups = SW360_AWS_security_groups
+      aws.block_device_mapping = [
+          {
+              'DeviceName' => SW360_AWS_device_mapping_name,
+              'VirtualName' => SW360_AWS_device_mapping_virtual_name,
+              'Ebs.VolumeSize' => SW360_AWS_device_mapping_ebs_size,
+              'Ebs.VolumeType' => SW360_AWS_device_mapping_type,
+              'Ebs.DeleteOnTermination' => true,
+          }
+      ]
+
+      # Tag each sw360 instance with a name
+      aws.tags = {
+          'Name' => SW360_basebox_name
+      }
+
+      # Specify username and private key path
+      override.ssh.username = SW360_AWS_ssh_user
+      override.ssh.private_key_path = SW360_AWS_ssh_private_key
+      override.nfs.functional = false
+    end
+
+  end
 
   # see: https://github.com/mitchellh/vagrant/pull/4707
   config.ssh.insert_key = false
@@ -32,9 +83,9 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
                           :mount_options => ["dmode=775"]
 
   facts = {
-    "tomcat_admin_password" => SW360_default_password,
-    "proxy_yes" => SW360_proxy,
-    "enable_mellon" => SW360_enable_mellon
+      "tomcat_admin_password" => SW360_default_password,
+      "proxy_yes" => SW360_proxy,
+      "enable_mellon" => SW360_enable_mellon
   }
 
   # setup proxy for vagrant plugin and puppet
@@ -46,19 +97,19 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
     sw360_http_proxy_split = SW360_proxy_http.rpartition(':')
     sw360_https_proxy_split = SW360_proxy_https.rpartition(':')
     if sw360_http_proxy_split.size == 3 && sw360_http_proxy_split[2] != "" && sw360_https_proxy_split.size == 3 && sw360_https_proxy_split[2] != ""
-      sw360_http_proxy_url  = sw360_http_proxy_split[0]
+      sw360_http_proxy_url = sw360_http_proxy_split[0]
       sw360_http_proxy_port = sw360_http_proxy_split[2]
       sw360_http_proxy_host = sw360_http_proxy_url.sub(/^https?\:\/\//, '')
-      sw360_https_proxy_url  = sw360_https_proxy_split[0]
+      sw360_https_proxy_url = sw360_https_proxy_split[0]
       sw360_https_proxy_port = sw360_https_proxy_split[2]
       sw360_https_proxy_host = sw360_https_proxy_url.sub(/^https?\:\/\//, '')
 
       facts.merge!({
-        "proxy_host_http" => sw360_http_proxy_host,
-        "proxy_port_http" => sw360_http_proxy_port,
-        "proxy_host_https" => sw360_https_proxy_host,
-        "proxy_port_https" => sw360_https_proxy_port
-      })
+                       "proxy_host_http" => sw360_http_proxy_host,
+                       "proxy_port_http" => sw360_http_proxy_port,
+                       "proxy_host_https" => sw360_https_proxy_host,
+                       "proxy_port_https" => sw360_https_proxy_port
+                   })
     end
   end
 
@@ -70,7 +121,8 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
   # Configuration for the base box (maven, jdk, thrift, tomcat, apache2)
   config.vm.provision :puppet, :module_path => "../puppet/modules" do |puppet|
     puppet.manifests_path = "../puppet/manifests"
-    puppet.manifest_file  = "sw360-base.pp"
+    puppet.manifest_file = "sw360-base.pp"
     puppet.facter = facts
   end
+
 end

--- a/puppet/manifests/sw360-base.pp
+++ b/puppet/manifests/sw360-base.pp
@@ -18,11 +18,19 @@ class box-configuration {
   class { 'apt':
     always_apt_update => true;
   }
-  apt::ppa { 'ppa:openjdk-r/ppa': }
 
-  package {["unzip", "curl", "git-core", "maven", "openjdk-8-jdk", "couchdb", "postgresql-9.5", "apache2", "libapache2-mod-auth-mellon"]:
-    ensure => present,
+  apt::ppa { 'ppa:openjdk-r/ppa':
+    before => [Exec['install-openjdk']]
+  }
+
+  package { ["unzip", "curl", "git-core", "maven", "openjdk-8-jdk", "couchdb", "postgresql-9.5", "apache2",
+    "libapache2-mod-auth-mellon"]:
+    ensure  => present,
     require => Class['apt'],
+  }
+
+  exec { 'install-openjdk':
+    command => "/usr/bin/apt-get -q -y --force-yes -o DPkg::Options::=--force-confold install openjdk-8-jdk",
   }
 
   ##############################################################################
@@ -134,10 +142,10 @@ class box-configuration {
     require => [User['siemagrant'],File[$tomcat_path]],
     creates => "${tomcat_path}/LICENSE",
   }
-  
+
 #------------------------------------------------------------
-# NB: the following will only 
-# be necessary when tomcat 8 is used    
+# NB: the following will only
+# be necessary when tomcat 8 is used
 #------------------------------------------------------------
 # Disable tomcat caching to avoid excessive log output
 #  file { 'context.xml':
@@ -184,14 +192,14 @@ class box-configuration {
     ensure  => absent,
     require => File[$liferay_data_path],
   }
-  
+
   # Ensure tomcat config path
   file { $tomcatconf_path:
     ensure  => 'directory',
     owner   => 'siemagrant',
     require => User['siemagrant'],
   }
-  
+
   # Configuration ROOT.xml that allows multiple web apps to use
   file { 'ROOT.xml':
     path    => "${tomcat_path}/conf/Catalina/localhost/ROOT.xml",
@@ -200,7 +208,7 @@ class box-configuration {
     ensure  => present,
     require => File[$tomcatconf_path],
   }
-  
+
   # Configuration to make ext libs available for liferay
   file { 'catalina.properties':
     path    => "${tomcat_path}/conf/catalina.properties",

--- a/shared/configuration.rb
+++ b/shared/configuration.rb
@@ -29,27 +29,45 @@ SW360_admin_name="setup" # admin account name for liferay (only!)
 SW360_vm_name="sw360-single" # how the vm is named in your hypervisor
 SW360_basebox_name="sw360-xenial" # which base box vagrant should consider
 SW360_vagrant_user="siemagrant" # the user created and used for the installation process
+SW360_enable_mellon=false # set to true to prepare for SAML authentication by installing and enabling mod_auth_mellon
+SW360_use_insecure_Keypair=true # setting this to true forces Vagrant to use the keypair in shared/insecureKeypair
 
-# set to true to prepare for saml authentication by installing and enabling mod_auth_mellon
-SW360_enable_mellon=false
-
-SW360_use_insecure_Keypair=false # setting this to true forces Vagrant to use the keypair in shared/insecureKeypair
-
-SW360_CPUs=4
-SW360_RAM=8192
-
-SW360_https_port=8443
+SW360_https_port=8443 # https port
 SW360_couchDB_port=5984 # set to "" to stop forwarding couchdb
 SW360_tomcat_debug_port=5005 # set to "" to deactivate tomcat debugging
-SW360_max_upload_filesize="1000m" # set the max upload files size in nginx in MB
+SW360_max_upload_filesize="1000m" # set the max upload files size in apache in MB
 
 # Setting the following variable will overwrite all git settings
-# For good performance this requires a Vagrant of version >= 1.5   
+# For good performance this requires a Vagrant of version >= 1.5
 # For synchronization you might have to start `vagrant rsync-auto` manually
 SW360_source=""
-
 SW360_gitURL="https://github.com/eclipse/sw360.git"
 SW360_branch="" # the value "" means: "don't change the branch"
+SW360_fossology_address="172.16.101.143" # FOSSology configuration:
 
-# FOSSology configuration:
-SW360_fossology_address="172.16.101.143"
+# Vagrant provider system
+SW360_provider="virtualbox" # available providers for vagrant: virtualbox, aws
+
+# Virtualbox section
+# Please refer to SW360_provider and set the value to virtualbox
+SW360_VB_CPUs=4
+SW360_VB_RAM=8192
+
+# AWS section
+# Please refer to SW360_provider and set the value to aws
+# Set your AWS environment variables 'AWS_ACCESS_KEY_ID', 'AWS_SECRET_ACCESS_KEY'
+SW360_AWS_keypair_name="" # specify the key pair name in your AWS account # e.g. vagrant-aws-key
+SW360_AWS_region="" # e.g. eu-central-1
+SW360_AWS_availability_zone="" # e.g. eu-central-1a
+SW360_AWS_subnet_id="" # e.g. subnet-23b9e7h1
+SW360_AWS_ami_base="" # Ubuntu Xenial AMI (depends on region and available AMI's) e.g. ami-7c412f13
+SW360_AWS_ami_single="" # generated basebox AMI (output of generate_box.sh) e.g. ami-b294cc59
+SW360_AWS_security_groups=['default'] # e.g. 'default', sg-945eeaf9
+SW360_AWS_ssh_user="" # e. g. ubuntu
+SW360_AWS_ssh_private_key="" # specify the path of the private key pem file
+# AWS specific machine settings
+SW360_AWS_instance_type="" # e.g. m4.large
+SW360_AWS_device_mapping_name="" # e.g. /dev/sdl
+SW360_AWS_device_mapping_virtual_name="" # e.g. sw360 device
+SW360_AWS_device_mapping_ebs_size=100 # e. g. 100
+SW360_AWS_device_mapping_type="" # e.g. gp2 (SSD) or magnetic (HDD) storage

--- a/shared/scripts/generate-keys.sh
+++ b/shared/scripts/generate-keys.sh
@@ -42,6 +42,7 @@ publicKey="$privateKey.pub"
 mkdir -p /home/siemagrant/.ssh
 cat "$publicKey" > /home/siemagrant/.ssh/authorized_keys
 chown -R siemagrant:siemagrant /home/siemagrant/.ssh/
+chmod 700 /home/siemagrant/.ssh/
 chmod 600 /home/siemagrant/.ssh/authorized_keys
 
 if [ ! "$SW360_use_insecure_Keypair" = true ]; then

--- a/sw360-single/Vagrantfile
+++ b/sw360-single/Vagrantfile
@@ -8,43 +8,97 @@
 # -*- mode: ruby -*-
 # vi: set ft=ruby :
 
+# Require configuration settings
 require_relative "../shared/configuration.rb"
+
+# Require the AWS provider plugin
+require 'vagrant-aws'
 
 VAGRANTFILE_API_VERSION = "2"
 
 Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
 
-  # Personalization for sw360
+  # ssh configuration
   config.ssh.username = SW360_vagrant_user
+
   if SW360_use_insecure_Keypair == true
     config.ssh.private_key_path = "../shared/insecureKeypair/siemagrant"
   else
     config.ssh.private_key_path = "../shared/siemagrant_key_for_" + SW360_basebox_name
   end
+
+  if SW360_provider == "virtualbox"
+
+    # Every Vagrant virtual box environment requires a box to build off of.
+    config.vm.box = SW360_basebox_name
+    config.vm.boot_timeout = 600
+
+    if SW360_network_host == true
+      config.vm.network "private_network", ip: "192.168.1.200"
+    end
+    if SW360_https_port
+      config.vm.network "forwarded_port", guest: 8443, host: SW360_https_port
+    end
+    if SW360_couchDB_port
+      config.vm.network "forwarded_port", guest: 5984, host: SW360_couchDB_port
+    end
+    if SW360_tomcat_debug_port
+      config.vm.network "forwarded_port", guest: 5005, host: SW360_tomcat_debug_port
+    end
+
+    # Virtualbox provider
+    config.vm.provider :virtualbox do |v|
+      v.name = SW360_vm_name
+      v.customize ["modifyvm", :id, "--cpus", SW360_VB_CPUs, "--memory", SW360_VB_RAM]
+    end
+
+  else
+
+    # Every Vagrant virtual box environment requires a box to build off of.
+    # AWS can use a dummy box because its using a AMI anyway.
+    config.vm.box = 'aws-dummy'
+
+    # AWS provider
+    config.vm.provider :aws do |aws, override|
+
+      # Read AWS authentication information from environment variables
+      aws.access_key_id = ENV['AWS_ACCESS_KEY_ID']
+      aws.secret_access_key = ENV['AWS_SECRET_ACCESS_KEY']
+
+      # Specify SSH keypair to use for the EC2 instance
+      aws.keypair_name = SW360_AWS_keypair_name
+
+      # Specify region, AMI ID, and security group(s)
+      aws.region = SW360_AWS_region
+      aws.availability_zone = SW360_AWS_availability_zone
+      aws.ami = SW360_AWS_ami_single
+      aws.instance_type = SW360_AWS_instance_type
+      aws.subnet_id = SW360_AWS_subnet_id
+      aws.security_groups = SW360_AWS_security_groups
+      aws.block_device_mapping = [
+          {
+              'DeviceName' => SW360_AWS_device_mapping_name,
+              'VirtualName' => SW360_AWS_device_mapping_virtual_name,
+              'Ebs.VolumeSize' => SW360_AWS_device_mapping_ebs_size,
+              'Ebs.VolumeType' => SW360_AWS_device_mapping_type,
+              'Ebs.DeleteOnTermination' => false,
+          }
+      ]
+
+      # Tag each sw360 instance with a name
+      aws.tags = {
+          'Name' => SW360_vm_name
+      }
+
+      # Set options for NFS
+      override.nfs.functional = false
+
+    end
+
+  end
+
   # see: https://github.com/mitchellh/vagrant/pull/4707
   config.ssh.insert_key = false
-
-  config.vm.provider "virtualbox" do |v|
-      v.name = SW360_vm_name
-      v.customize ["modifyvm", :id, "--cpus", SW360_CPUs, "--memory", SW360_RAM]
-      config.vm.boot_timeout = 600
-  end
-
-  config.vm.box = SW360_basebox_name
-  config.vm.define SW360_vm_name
-
-  if SW360_network_host == true
-    config.vm.network "private_network", ip: "192.168.1.200"
-  end
-  if SW360_https_port
-    config.vm.network "forwarded_port", guest: 8443, host: SW360_https_port
-  end
-  if SW360_couchDB_port
-    config.vm.network "forwarded_port", guest: 5984, host: SW360_couchDB_port
-  end
-  if SW360_tomcat_debug_port
-    config.vm.network "forwarded_port", guest: 5005, host: SW360_tomcat_debug_port
-  end
 
   config.vm.synced_folder "../shared", "/vagrant_shared"
 
@@ -65,30 +119,30 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
   # SW360 specific configuration
   config.vm.provision :puppet, :module_path => "../puppet/modules" do |puppet|
     puppet.manifests_path = "../puppet/manifests"
-    puppet.manifest_file  = "sw360-single.pp"
+    puppet.manifest_file = "sw360-single.pp"
 
     puppet.facter = {
-      "proxy_yes" => SW360_proxy,
-      "https_port" => SW360_https_port,
-      "tomcat_admin_password" => SW360_default_password,
-      "liferay_admin_password" => SW360_default_password,
-      "liferay_admin_name" => SW360_admin_name,
-      "fossology_address" => SW360_fossology_address,
-      "max_upload_filesize" => SW360_max_upload_filesize
+        "proxy_yes" => SW360_proxy,
+        "https_port" => SW360_https_port,
+        "tomcat_admin_password" => SW360_default_password,
+        "liferay_admin_password" => SW360_default_password,
+        "liferay_admin_name" => SW360_admin_name,
+        "fossology_address" => SW360_fossology_address,
+        "max_upload_filesize" => SW360_max_upload_filesize,
     }
   end
 
-  if not File.exists?(File.join(File.dirname(__FILE__),".vagrant/action_provision"))
+  if not File.exists?(File.join(File.dirname(__FILE__), ".vagrant/action_provision"))
     config.vm.provision "shell", run: "always" do |s|
-      s.path       = "sw360-install.sh"
-      s.args       = [ "-0" ]
+      s.path = "sw360-install.sh"
+      s.args = ["-0"]
       s.privileged = false
     end
   end
 
   if SW360_install == true
     config.vm.provision "shell" do |s|
-      s.path       = "sw360-install.sh"
+      s.path = "sw360-install.sh"
       s.privileged = false
     end
   end


### PR DESCRIPTION
**Preparation:**
Please install the following plugin for vagrant
`vagrant plugin install vagrant-aws`


**download-packages.sh**
- download dummy.box for AWS vagrant
- vagrant box add dummy.box

**configuration.rb**
- add provider switch (`SW360_provider`)
- add AWS section with configuration properties (AWS provider)

**Vagrantfile**
- updated Vagrantfile for base and single box

**How to use it:**
- Setup configuration.rb with aws configuration
- run ./generate_box.sh
- add base-box AMI to configuration.rb (`SW360_AWS_ami_single`)
- run vagrant up (sw360-single)
