### PR TITLE
chore(setup): Change default SW360 repository to Eclipse

### DIFF
--- a/shared/configuration.rb
+++ b/shared/configuration.rb
@@ -48,7 +48,7 @@ SW360_max_upload_filesize="1000m" # set the max upload files size in nginx in MB
 # For synchronization you might have to start `vagrant rsync-auto` manually
 SW360_source=""
 
-SW360_gitURL="https://github.com/sw360/sw360portal.git"
+SW360_gitURL="https://github.com/eclipse/sw360.git"
 SW360_branch="" # the value "" means: "don't change the branch"
 
 # FOSSology configuration:

--- a/sw360-single/sw360-install.sh
+++ b/sw360-single/sw360-install.sh
@@ -138,14 +138,17 @@ if [ -z $SW360_source ]; then
         if [ -d "$wd/.git/" ]; then
             cd "$wd"
             git checkout $SW360_branch || git checkout -b $SW360_branch
-            git pull $SW360_gitURL $SW360_branch
+            git fetch
+            git reset --hard origin/$SW360_branch
         else
             git clone -b $SW360_branch --single-branch $SW360_gitURL "$wd"
         fi
     else
         if [ -d "$wd/.git/" ]; then
             cd "$wd"
-            git pull $SW360_gitURL
+            currentBranch=$(git rev-parse --abbrev-ref HEAD)
+            git fetch
+            git reset --hard origin/$currentBranch
         else
             git clone --single-branch $SW360_gitURL "$wd"
         fi


### PR DESCRIPTION
- changes the default repository from sw360portal to eclipse/sw360
- bugfix regarding `git pull` (needs at least user configuration name and e-mail)

closes sw360/sw360vagrant#19