### PR TITLE
fixed build procedure by adding missing but required `base.deploy.dir`

### DIFF
--- a/generate-box/Vagrantfile
+++ b/generate-box/Vagrantfile
@@ -34,7 +34,8 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
   facts = {
     "tomcat_admin_password" => SW360_default_password,
     "proxy_yes" => SW360_proxy,
-    "enable_mellon" => SW360_enable_mellon
+    "enable_mellon" => SW360_enable_mellon,
+    "maven_base_deploy_dir" => SW360_deploy_dir
   }
 
   # setup proxy for vagrant plugin and puppet

--- a/puppet/manifests/sw360-base.pp
+++ b/puppet/manifests/sw360-base.pp
@@ -105,6 +105,13 @@ class box-configuration {
     require => Package['maven'],
   }
 
+  # ensure existence of `base.deploy.dir`
+  file { $maven_base_deploy_dir:
+    ensure  => 'directory',
+    owner   => 'siemagrant',
+    require => User['siemagrant'],
+  }
+
   ##################
   ## Thrift Setup ##
   ##################

--- a/puppet/modules/sw360/templates/maven_settings.xml.erb
+++ b/puppet/modules/sw360/templates/maven_settings.xml.erb
@@ -228,6 +228,13 @@ under the License.
     </profile>
     -->
 
+    <profile>
+      <id>sw360vagrant</id>
+      <properties>
+        <base.deploy.dir>/opt/sw360</base.deploy.dir>
+      </properties>
+    </profile>
+
     <!--
      | Here is another profile, activated by the system property 'target-env' with a value of 'dev',
      | which provides a specific path to the Tomcat instance. To use this, your plugin configuration
@@ -267,9 +274,10 @@ under the License.
   <!-- activeProfiles
    | List of profiles that are active for all builds.
    |
-  <activeProfiles>
-    <activeProfile>alwaysActiveProfile</activeProfile>
-    <activeProfile>anotherAlwaysActiveProfile</activeProfile>
-  </activeProfiles>
   -->
+  <activeProfiles>
+    <!--<activeProfile>alwaysActiveProfile</activeProfile>-->
+    <!--<activeProfile>anotherAlwaysActiveProfile</activeProfile>-->
+    <activeProfile>sw360vagrant</activeProfile>
+  </activeProfiles>
 </settings>

--- a/shared/configuration.rb
+++ b/shared/configuration.rb
@@ -53,3 +53,5 @@ SW360_branch="" # the value "" means: "don't change the branch"
 
 # FOSSology configuration:
 SW360_fossology_address="172.16.101.143"
+
+SW360_deploy_dir="/opt/sw360"


### PR DESCRIPTION
* introducing a new deploy profile (https://github.com/eclipse/sw360/commit/7d9e30e7b1b070c0eaef720175464cfbf2c9643b) broke the vagrant deployment
* since the property is defined by the deployment instead and not by the application itself,
  the maven settings are utilized here to set the dir for this specific use case