### PR TITLE
making sw360vagrant compatible for sw360-12.0.0-M1

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ Bascially, the vagrant install is about the following:
 
 The main reason why downloading pakages and creating the base box is separate
 from vagrant provisioning is that downloading and provisioning of dependencies
-takes some time. And this not necessary every time a deployment is started.
+takes some time. And this not necessary every time a new deployment is started.
 
 Please see details about this below. Tested with linux, windows and macosx. The hardware requirements can bee seen in the `shred/configuration.rb` file.
 
@@ -26,11 +26,12 @@ Clone from this repository.
 
 if you need to use a proxy server please follow this additional instructions before starting with the next chapter:
 
-* install the AWS plugin for vagrant if you setup AWS as provider
+* install the AWS plugin for vagrant (also if you do not setup AWS as provider)
 ```
 $ vagrant plugin install vagrant-aws
 ```
 (although you will not deploy to AWS, it is required, because vagrant parses the description files and finds some conditional statements which are not ignored)
+
 * install the disk size plugin for vagrant to change the virtual disk size (new!)
 ```
 $ vagrant plugin install vagrant-disksize
@@ -43,6 +44,8 @@ $ env | grep proxy
 ```
 $ vagrant plugin install vagrant-proxyconf
 ```
+Again, even if you do not need to use the functionality you will need to install the plug-ins, because vagrant cannot parse the vagrant file  other wise.
+
 * adapt the Vagrantfile in the generate-box folder to set the proxy information
 ```
 $ vi shared/configuration.rb
@@ -153,16 +156,16 @@ $ vagrant destroy,
 ```
 run steps 2, 3 and 4 again in order to install the maven repository to the box. This makes building the sw360 project a lot quicker in the future. After that, proceed with step 6.
 
-### 7. Deploying the SW360 layout to Liferay
+### 7. (not optional) Deploying the SW360 layout to Liferay
 
 The last step is to manually deploy the site layout into Liferay (as sadly automatic
 deployment is not working). To that end, log in to the Liferay instance (what ever was defined in the confguration.rb) as user `setup@sw360.org`, the default password is `sw360fossy` but it can be modified in the  configuration (`shared/configuration.rb`). Check whether the SW360 is present in Liferay.
 
 In order to further setup liferay, follow the wiki pages of this project or [the public repository] (https://github.com/eclipse/sw360/wiki/)
 
-Your SW360 is now ready!
+You really need to apply step 7 in order to complete the dpeloyment of sw360, it is not optional.
 
-### 8. Changing the external port
+### 8. (optional) Changing the external port
 
 If you want to change the port on which sw360 is accessible from its default 8443 to something else, this needs to be changed in two locations.
   * obviously the Vagrant file: `config.vm.network "forwarded_port", guest: 8443, host: <your_port_here>`

--- a/puppet/modules/sw360/templates/couchdb.properties.erb
+++ b/puppet/modules/sw360/templates/couchdb.properties.erb
@@ -25,6 +25,4 @@ lucenesearch.limit = 150
 # [lucene]
 # allowLeadingWildcard=true
 # see more: https://wiki.apache.org/lucene-java/LuceneFAQ#What_wildcard_search_support_is_available_from_Lucene.3F
-lucenesearch.leading.wildcard = false
-
-
+lucenesearch.leading.wildcard = true

--- a/puppet/modules/sw360/templates/liferay_portal-ext.properties.erb
+++ b/puppet/modules/sw360/templates/liferay_portal-ext.properties.erb
@@ -20,7 +20,7 @@ company.default.web.id=sw360.org
 # Needed SW360 roles
 # (https://github.com/liferay/liferay-portal/blob/7.2.0-ga1/portal-impl/src/portal.properties#L2502)
 # Keep this inline with sw360-portlet/**/PortalConstants#Role names
-system.site.roles=Clearing Admin, ECC Admin, Security Admin, SW360 Admin
+system.site.roles=Clearing Admin, Clearing Expert, ECC Admin, Security Admin, SW360 Admin
 
 # Jump to SW360 Homepage (Dashboard) after login
 # (https://github.com/liferay/liferay-portal/blob/7.2.0-ga1/portal-impl/src/portal.properties#L4333)

--- a/puppet/modules/sw360/templates/sw360.properties.erb
+++ b/puppet/modules/sw360/templates/sw360.properties.erb
@@ -56,9 +56,15 @@
 
 #preferred.country.codes=DE,AT,CH,US
 
+#project.obligation.actions=Action 1,Action 2,Action 3
+
 #programming.languages=[ "ActionScript", "AppleScript", "Asp","Bash", "BASIC", "C", "C++", "C#", "Cocoa", "Clojure","COBOL","ColdFusion", "D", "Delphi", "Erlang", "Fortran", "Go", "Groovy","Haskell", "JSP", "Java","JavaScript", "Objective-C", "Ocaml","Lisp", "Perl", "PHP", "Python", "Ruby", "SQL", "SVG","Scala","SmallTalk", "Scheme", "Tcl", "XML", "Node.js", "JSON" ]
 
 #project.externalkeys=internal.id
+
+clearing.team.unknown.enabled=true
+
+project.obligations.enabled=true
 
 ## used in the projectimport-portlet UI, comma separated list of hosts
 ## 	Example: https://some.host.domain,https://some.other.host.domain
@@ -88,11 +94,11 @@
 #enable.custom.mapping=false
 
 ## API Token generation
-#rest.apitoken.generator.enable=true
-#rest.apitoken.read.validity.days=90
-#rest.apitoken.write.validity.days=30
-#rest.apitoken.hash.salt=$2a$04$Software360RestApiSalt
-#rest.write.access.usergroup=User
+rest.apitoken.generator.enable=true
+rest.apitoken.read.validity.days=90
+rest.apitoken.write.validity.days=30
+rest.apitoken.hash.salt=$2a$04$Software360RestApiSalt
+rest.write.access.usergroup=User
 
 # ---------------------------------------
 # Activation of portlets and components

--- a/puppet/modules/sw360/templates/sw360.properties.erb
+++ b/puppet/modules/sw360/templates/sw360.properties.erb
@@ -94,11 +94,11 @@ project.obligations.enabled=true
 #enable.custom.mapping=false
 
 ## API Token generation
-rest.apitoken.generator.enable=true
-rest.apitoken.read.validity.days=90
-rest.apitoken.write.validity.days=30
-rest.apitoken.hash.salt=$2a$04$Software360RestApiSalt
-rest.write.access.usergroup=User
+#rest.apitoken.generator.enable=true
+#rest.apitoken.read.validity.days=90
+#rest.apitoken.write.validity.days=30
+#rest.apitoken.hash.salt=$2a$04$Software360RestApiSalt
+#rest.write.access.usergroup=User
 
 # ---------------------------------------
 # Activation of portlets and components

--- a/shared/couchdb-lucene.ini
+++ b/shared/couchdb-lucene.ini
@@ -27,7 +27,7 @@ timeout=10000
 limit=25
 
 # Allow leading wildcard?
-allowLeadingWildcard=false
+allowLeadingWildcard=true
 
 # couchdb server mappings
 


### PR DESCRIPTION
Making vagrant fir for tagging 2.0 for sync with sw360 tag 12.0.0-M1 and adding some feedback:

* fix bug with couchdb lucene search by enable allowleadingwildcard = true
* enabling the REST API token interface in Web UI
* adding role clearing expert
* switching on obligations interface in UI
* writing explicitly that the setup of the liferay is required to complete SW360 installation in README

Testing

just do the standard installation of SW360.