### PR TITLE
improve scripts and make vagrant-aws plugin an optional dependency

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,11 +26,10 @@ Clone from this repository.
 
 if you need to use a proxy server please follow this additional instructions before starting with the next chapter:
 
-* install the AWS plugin for vagrant (also if you do not setup AWS as provider)
+* (optional, for support of aws as provider) install the AWS plugin for vagrant
 ```
 $ vagrant plugin install vagrant-aws
 ```
-(although you will not deploy to AWS, it is required, because vagrant parses the description files and finds some conditional statements which are not ignored)
 
 * install the disk size plugin for vagrant to change the virtual disk size (new!)
 ```

--- a/download-packages.sh
+++ b/download-packages.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # -----------------------------------------------------------------------------
 # Copyright Siemens AG, 2013-2015, 2019. Part of the SW360 Portal Project.
@@ -18,6 +18,8 @@
 # modified: michael.c.jaeger@tngtech.com
 #
 # -----------------------------------------------------------------------------
+
+set -eo pipefail
 
 #
 # downloading all the big downloads

--- a/generate-box/Vagrantfile
+++ b/generate-box/Vagrantfile
@@ -11,8 +11,10 @@
 # Require configuration settings
 require_relative '../shared/configuration.rb'
 
-# Require the AWS provider plugin
-require 'vagrant-aws'
+unless ! Vagrant.has_plugin?("vagrant-aws")
+  # Require the AWS provider plugin
+  require 'vagrant-aws'
+end
 
 VAGRANTFILE_API_VERSION = "2"
 
@@ -33,6 +35,10 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
     end
 
   else
+
+    unless Vagrant.has_plugin?("vagrant-aws")
+      raise 'vagrant-aws is not installed!'
+    end
 
     # AWS can use a dummy box because its using a AMI anyway.
     config.vm.box = 'aws-dummy'

--- a/generate-box/generate_box.sh
+++ b/generate-box/generate_box.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # -----------------------------------------------------------------------------
 # Copyright Siemens AG, 2013-2015. Part of the SW360 Portal Project.
@@ -10,7 +10,7 @@
 #
 # -----------------------------------------------------------------------------
 
-set -e
+set -eo pipefail
 
 have() { type "$1" &> /dev/null; }
 have vagrant || {

--- a/sw360-single/Vagrantfile
+++ b/sw360-single/Vagrantfile
@@ -11,8 +11,10 @@
 # Require configuration settings
 require_relative "../shared/configuration.rb"
 
-# Require the AWS provider plugin
-require 'vagrant-aws'
+unless ! Vagrant.has_plugin?("vagrant-aws")
+  # Require the AWS provider plugin
+  require 'vagrant-aws'
+end
 
 VAGRANTFILE_API_VERSION = "2"
 
@@ -53,6 +55,10 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
     end
 
   else
+
+    unless Vagrant.has_plugin?("vagrant-aws")
+      raise 'vagrant-aws is not installed!'
+    end
 
     # Every Vagrant virtual box environment requires a box to build off of.
     # AWS can use a dummy box because its using a AMI anyway.


### PR DESCRIPTION
also the `vagrant-proxyconf` looks to be optional, was not necessary to be installed to get every thing started.