### PR TITLE
fix(dependencies): adding commons-compress as bundle dependency

### DIFF
--- a/download-packages.sh
+++ b/download-packages.sh
@@ -27,6 +27,7 @@ set -eo pipefail
 packages='https://cloud-images.ubuntu.com/bionic/current/bionic-server-cloudimg-amd64-vagrant.box
 https://sourceforge.net/projects/lportal/files/Liferay%20Portal/7.3.3%20GA4/liferay-ce-portal-tomcat-7.3.3-ga4-20200701015330959.tar.gz
 https://search.maven.org/remotecontent?filepath=commons-codec/commons-codec/1.12/commons-codec-1.12.jar commons-codec-1.12.jar
+https://repo1.maven.org/maven2/org/apache/commons/commons-compress/1.20/commons-compress-1.20.jar commons-compress-1.20.jar
 https://search.maven.org/remotecontent?filepath=org/apache/commons/commons-collections4/4.4/commons-collections4-4.4.jar commons-collections4-4.4.jar
 https://search.maven.org/remotecontent?filepath=org/apache/commons/commons-csv/1.4/commons-csv-1.4.jar commons-csv-1.4.jar
 https://search.maven.org/remotecontent?filepath=commons-io/commons-io/2.6/commons-io-2.6.jar commons-io-2.6.jar

--- a/shared/scripts/install-bundle-deps.sh
+++ b/shared/scripts/install-bundle-deps.sh
@@ -19,6 +19,7 @@ echo "-[shell provisioning] start installing bundle dependencies ..."
 #
 cp /vagrant_shared/packages/commons-codec-1.12.jar  /opt/liferay-ce-portal-7.3.3-ga4/deploy/commons-codec-1.12.jar
 cp /vagrant_shared/packages/commons-collections4-4.4.jar  /opt/liferay-ce-portal-7.3.3-ga4/deploy/commons-collections4-4.4.jar
+cp /vagrant_shared/packages/commons-compress-1.20.jar /opt/liferay-ce-portal-7.3.3-ga4/deploy/commons-compress-1.20.jar
 cp /vagrant_shared/packages/commons-csv-1.4.jar  /opt/liferay-ce-portal-7.3.3-ga4/deploy/commons-csv-1.4.jar
 cp /vagrant_shared/packages/commons-io-2.6.jar  /opt/liferay-ce-portal-7.3.3-ga4/deploy/commons-io-2.6.jar
 cp /vagrant_shared/packages/commons-lang-2.4.jar  /opt/liferay-ce-portal-7.3.3-ga4/deploy/commons-lang-2.4.jar


### PR DESCRIPTION
Just adding to 

* download-packages
* scripts/install-bundle-deps

the commons compress dependency which is required after updating libre office

Signed-off-by: Michael C. Jaeger <michael.c.jaeger@siemens.com>